### PR TITLE
Support QuickFix with empty metadata

### DIFF
--- a/autoload/jumptoline.vim
+++ b/autoload/jumptoline.vim
@@ -1,6 +1,6 @@
 
 let s:ps = [
-    \   { 'type' : 'quickfix', 'regex' : '^\([^|]*\)|\(\d\+\)\( col \(\d\+\)\)\?[^|]*|', 'path_i' : 1, 'lnum_i' : 2, 'col_i' : 4, },
+    \   { 'type' : 'quickfix', 'regex' : '^\([^|]*\)|\(\(\d\+\)\( col \(\d\+\)\)\?[^|]*\)\?|', 'path_i' : 1, 'lnum_i' : 3, 'col_i' : 5, },
     \   { 'type' : 'msbuild,C#,F#', 'regex' : '^\s*\(.*\)(\(\d\+\),\(\d\+\)):.*$', 'path_i' : 1, 'lnum_i' : 2, 'col_i' : 3, },
     \   { 'type' : 'VC', 'regex' : '^\s*\(.*\)(\(\d\+\))\s*:.*$', 'path_i' : 1, 'lnum_i' : 2, },
     \   { 'type' : 'Rust', 'regex' : '^\s*--> \(.*\.rs\):\(\d\+\):\(\d\+\)$', 'path_i' : 1, 'lnum_i' : 2, },


### PR DESCRIPTION
Sometimes we create a QuickFix with only the file name from fzf etc.
In that case, the metadata other than the file name is not included in the QuickFix, but even in that case, it is determined that it is QuickFix and jumping can be performed.
![スクリーンショット 2020-02-06 17 17 32](https://user-images.githubusercontent.com/5423775/73924275-8f8de680-490f-11ea-864e-7d0cba90ac44.png)
